### PR TITLE
Update dumphfdl.service

### DIFF
--- a/etc/dumphfdl.service
+++ b/etc/dumphfdl.service
@@ -11,7 +11,7 @@ EnvironmentFile=/etc/default/dumphfdl
 # the following line and put a desired user name in it.
 # Note that the user must have access to the SDR device.
 #User=pi
-ExecStart=/usr/local/bin/dumphfdl $DUMPVDL2_OPTIONS
+ExecStart=/usr/local/bin/dumphfdl $DUMPHFDL_OPTIONS
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
The ExecStart refers to DUMPVDL2 options in the /etc/default file, whereas it shoud be DUMPHFDL