### PR TITLE
Fix segfaults on shutdown from systemd under ka9q-radio

### DIFF
--- a/src/input-file.c
+++ b/src/input-file.c
@@ -49,6 +49,8 @@ void *file_input_thread(void *ctx) {
 	size_t space_available, len, samples_read;
 	do {
 		len = fread(inbuf, 1, bufsize, file_input->fh);
+		if(len == 0)
+		  break; // probably not necessary, but to make sure
 		samples_read = len / input->bytes_per_sample;
 		while(true) {
 			pthread_mutex_lock(circ_buffer->mutex);
@@ -62,6 +64,7 @@ void *file_input_thread(void *ctx) {
 		input->convert_sample_buffer(input, inbuf, len, outbuf);
 		complex_samples_produce(circ_buffer, outbuf, samples_read);
 	} while(len > 0 && do_exit == 0);
+	fprintf(stderr,"dumphfdl pid %d: EOF on input, terminating\n",getpid());
 	fclose(file_input->fh);
 	file_input->fh = NULL;
 	debug_print(D_MISC, "Shutdown ordered, signaling consumer shutdown\n");

--- a/src/input-soapysdr.c
+++ b/src/input-soapysdr.c
@@ -251,6 +251,7 @@ void *soapysdr_input_thread(void *ctx) {
 			err_cnt++;
 			if(err_cnt >= SOAPYSDR_MAX_ERR_CNT) {
 				do_exit = 1;
+				fprintf(stderr,"dumphfdl pid %d: error on soapysdr_input, terminating\n",getpid());
 				exitcode = EXIT_FAILURE;
 				break;
 			}

--- a/src/main.c
+++ b/src/main.c
@@ -52,13 +52,8 @@ static void start_all_output_threads_for_fmtr(void *p, void *ctx);
 static void start_output_thread(void *p, void *ctx);
 
 static void sighandler(int32_t sig) {
-	fprintf(stderr, "Got signal %d, ", sig);
-	if(do_exit == 0) {
-		fprintf(stderr, "exiting gracefully (send signal once again to force quit)\n");
-	} else {
-		fprintf(stderr, "forcing quit\n");
-	}
-	do_exit++;
+  fprintf(stderr, "dumphfdl pid %d: got signal %d\n", getpid(), sig);
+  do_exit = 1;
 }
 
 static void setup_signals() {
@@ -790,14 +785,13 @@ int32_t main(int32_t argc, char **argv) {
 		sleep(1);
 	}
 	hfdl_pdu_decoder_stop();
-	fprintf(stderr, "Waiting for all threads to finish\n");
-	while(do_exit < 2 && (
-			block_is_running(input) ||
+	fprintf(stderr, "dumphfdl pid %d: Waiting for all threads to finish\n",getpid());
+	while(block_is_running(input) ||
 			block_is_running(fft) ||
 			block_set_is_any_running(channel_cnt, channel_blocks) ||
 			hfdl_pdu_decoder_is_running() ||
 			output_thread_is_any_running(outputs)
-			)) {
+			) {
 		usleep(500000);
 	}
 


### PR DESCRIPTION
I run dumphfdl as a client of my ka9q-radio multichannel receiver. My program 'pcmrecord' receives the multicast signal stream and pipes it to dumphfdl's stdin. When systemd shuts down the hfdl service, pcmrecord exits and passes EOF to dumphfdl, which sets the do_exit flag to begin an orderly shutdown.

But before it could finish, dumphfdl got a SIGTERM from systemd that incremented do_exit to 2, aborting the clean shutdown and resulting in the logged segfaults. Since systemd only sends SIGTERM once, there's no benefit to incrementing do_exit in the signal handler so I removed that code. Systemd will still follow up with SIGKILL if dumphfdl really does get stuck; that's a better way to deal with a recalcitrant process.

I also added the process ID to the EOF and signal handler messages to aid in debugging a multistream system.